### PR TITLE
Add item image to purchase text. Allow generating shop contents from RollTable.

### DIFF
--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -198,8 +198,13 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
                         let buyChat = game.settings.get("lootsheetnpc5e", "buyChat");
 
                         if (buyChat) {
-                            let message = `${currentActor.name} purchases ${quantity} x ${newItem.name} for ${itemCost}gp.`;
-                            //message += msg.join(",");
+                            let message = `
+                            <img src="${newItem.img}" height="30">
+                            <p>
+                                ${currentActor.name} purchases ${quantity} x ${newItem.name} for ${itemCost}gp.
+                            </p>
+                            `;
+                            
                             ChatMessage.create({
                                 user: game.user._id,
                                 speaker: {

--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -75,6 +75,9 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
             } else {
                 html.find('.price-modifier').click(ev => this._priceModifier(ev));
             }
+
+            html.find('.merchant-settings').change(ev => this._merchantSettingChange(ev));
+            html.find('.update-inventory').click(ev => this._merchantInventoryUpdate(ev));
         }
 
         // Buy Item
@@ -83,6 +86,80 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
         // Sheet Type
         html.find('.sheet-type').change(ev => this._changeSheetType(ev, html));
 
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Handle merchant settings change
+     * @private
+     */
+    async _merchantSettingChange(event, html) {
+        event.preventDefault();
+        console.log("Loot Sheet | Merchant settings changed");
+
+        const moduleNamespace = "lootsheetnpc5e";
+        const expectedKeys = ["rolltable", "shopQty", "itemQty"];
+
+        let targetKey = event.target.name.split('.')[3];
+
+        if (expectedKeys.indexOf(targetKey) === -1) {
+            console.log(`Loot Sheet | Error changing stettings for "${targetKey}".`);
+            return ui.notifications.error(`Error changing stettings for "${targetKey}".`);
+        }
+
+        if (event.target.value) {
+            await this.actor.setFlag(moduleNamespace, targetKey, event.target.value);
+        } else {
+            await this.actor.unsetFlag(moduleNamespace, targetKey, event.target.value);
+        }
+    }
+
+    /* -------------------------------------------- */
+
+    /**
+     * Handle merchant inventory update
+     * @private
+     */
+    async _merchantInventoryUpdate(event, html) {
+        event.preventDefault();
+        console.log("Loot Sheet | Merchant inventory update");
+
+        const moduleNamespace = "lootsheetnpc5e";
+        const rolltableName = this.actor.getFlag(moduleNamespace, "rolltable");
+        const shopQtyFormula = this.actor.getFlag(moduleNamespace, "shopQty") || "1";
+        const itemQtyFormula = this.actor.getFlag(moduleNamespace, "itemQty") || "1";
+
+        let rolltable = game.tables.getName(rolltableName);
+        if (!rolltable) {
+            console.log(`Loot Sheet | No RollTable found with name "${rolltableName}".`);
+            return ui.notifications.error(`No RollTable found with name "${rolltableName}".`);
+        }
+
+        let currentItems = this.actor.data.items.map(i => i._id);
+        await this.actor.deleteEmbeddedEntity("OwnedItem", currentItems);
+        
+        let shopQtyRoll = new Roll(shopQtyFormula);
+
+        shopQtyRoll.roll();
+        console.log(`Loot Sheet | Adding ${shopQtyRoll.result} new items`);
+
+        for (let i = 0; i < shopQtyRoll.result; i++) {
+            const rollResult = rolltable.roll();
+
+            let newItem = game.items.get(rollResult[1].resultId);
+            if (!newItem) {
+                console.log(`Loot Sheet | No item found "${rollResult[1].resultId}".`);
+                ui.notifications.error(`No RollTable found with name "${rolltableName}".`);
+            }
+
+            let itemQtyRoll = new Roll(itemQtyFormula);
+            itemQtyRoll.roll();
+            console.log(`Loot Sheet | Adding ${itemQtyRoll.result} x ${newItem.name}`)
+            newItem.data.data.quantity = itemQtyRoll.result;
+
+            await this.actor.createEmbeddedEntity("OwnedItem", newItem);
+        }
     }
 
     /* -------------------------------------------- */

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -58,16 +58,32 @@
                         </li>
                     {{/each}}
                 </ol>
-                <h3 class="gm-header"><i class="fas fa-coins"></i> Coin Distribution</h3>
-                <ol class="coins-list">
-                    {{#each actor.flags.loot.currency as |c i|}}
-                        <li class="denomination {{i}}">
-                            <label>{{ lookup ../config.currencies i }}:</label>
-                            <h4 class="denomination-value">{{c.value}} each</h4>
-                        </li>
-                    {{/each}}
-                </ol>
-                <button class= "split-coins" type="split-coins" name="split-coins" value="1"><i class="fa fa-coins"></i> Split {{actor.flags.loot.ownerCount}} Ways</button>
+
+                {{#ifeq lootsheettype "Loot"}}
+                    <h3 class="gm-header"><i class="fas fa-coins"></i> Coin Distribution</h3>
+                    <ol class="coins-list">
+                        {{#each actor.flags.loot.currency as |c i|}}
+                            <li class="denomination {{i}}">
+                                <label>{{ lookup ../config.currencies i }}:</label>
+                                <h4 class="denomination-value">{{c.value}} each</h4>
+                            </li>
+                        {{/each}}
+                    </ol>
+                    <button class= "split-coins" type="split-coins" name="split-coins" value="1"><i class="fa fa-coins"></i> Split {{actor.flags.loot.ownerCount}} Ways</button>
+                {{/ifeq}}
+
+                {{#ifeq lootsheettype "Merchant"}}
+                    <h3 class="gm-header"><i class="fas fa-balance-scale"></i> Merchent Settings</h3>
+                    <div class="merchant-settings">
+                        <h4 class="">Inventory RollTable: </h4>
+                        <input name="data.flags.lootsheetnpc5e.rolltable" type="text" data-dtype="String" placeholder="e.g. MyShopRollTable" value="{{data.flags.lootsheetnpc5e.rolltable}}"/>
+                        <h4 class="">Shop Quantity Formula: </h4>
+                        <input name="data.flags.lootsheetnpc5e.shopQty" type="text" data-dtype="String" placeholder="e.g. 1d20" value="{{data.flags.lootsheetnpc5e.shopQty}}"/>
+                        <h4 class="">Item Quantity Formula: </h4>
+                        <input name="data.flags.lootsheetnpc5e.itemQty" type="text" data-dtype="String" placeholder="e.g. 1d20" value="{{data.flags.lootsheetnpc5e.itemQty}}"/>
+                    </div>
+                    <button class="update-inventory" type="update-inventory" name="update-inventory" value="1"><i class="fas fa-balance-scale"></i> Update Shop Inventory</button>
+                {{/ifeq}}
             </div>
 
             {{/if}}


### PR DESCRIPTION
The first change is a small change that adds the image of the item being purchased to the chat output.

The second (and real change) is the ability to generate your shop inventory from a RollTable. You can now provide a RollTable name, a dice roll formula for quantity of items in the shop and a dice roll formula for quantity of each item place in the shop (in preparation for when the shop inventory can be depleted).

~I want to follow this up with another PR that allows rolltable recursion so that you can setup your store generation as complicated as you like. Currently it expects everything within the chosen rolltable returns an item reference.~

Edit: Upon further investigation, RollTables will automatically recurse when you nest them... who knew  ¯\\\_(ツ)\_/¯

Have a bit of a play and see what you think!

As I was working on this I was beginning to think that the merchant sheet and the loot sheet should in-fact be two different templates... I feel like they are starting to meaningfully diverge though I would like to know your thoughts :)