### PR TITLE
Fix bug having multiple npc sheets modals opened.

### DIFF
--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -16,15 +16,6 @@
             {{/if}}
         </header>
 
-        {{#ifeq lootsheettype "Loot"}}
-            <style>.item-loot { display: block !important; }</style>
-        {{/ifeq}}
-
-        {{#ifeq lootsheettype "Merchant"}}
-            <style>.item-buy { display: block !important; }</style>
-        {{/ifeq}}
-
-
     <section class="sheet-lower flexrow">
 
 		<!-- SIDEBAR -->
@@ -171,8 +162,15 @@
                                     </div>
                                     
                                     <div class="item-controls">
-                                        <a class="item-control item-buy" title="Buy Item" style="display: none;"><i class="fas fa-dollar-sign"></i></a>
-                                        <a class="item-control item-loot" title="Loot Item" style="display: none;"><i class="fas fa-gem"></i></a>
+
+                                        {{#ifeq ../../lootsheettype "Loot"}}
+                                            <a class="item-control item-loot" title="Loot Item"><i class="fas fa-gem"></i></a>
+                                        {{/ifeq}}
+
+                                        {{#ifeq ../../lootsheettype "Merchant"}}
+                                            <a class="item-control item-buy" title="Buy Item"><i class="fas fa-dollar-sign"></i></a>
+                                        {{/ifeq}}
+
                                         {{#if ../../owner}}
                                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
                                             <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>


### PR DESCRIPTION
CSS from one modal will affect the entire page.

This meant if you had a "Loot" sheet and a "Merchant" sheet open at the
same time, it would show both icons on both sheets.