### PR TITLE
NPC sheet 5e isn't provided as a default export.

### DIFF
--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -1,4 +1,4 @@
-import ActorSheet5eNPC from "../../systems/dnd5e/module/actor/sheets/npc.js";
+import { ActorSheet5eNPC } from "../../systems/dnd5e/module/actor/sheets/npc.js";
 
 class QuantityDialog extends Dialog {
     constructor(callback, options) {


### PR DESCRIPTION
Without these `{ }` the module never loads.