### PR TITLE
Option for larger price modifiers

### DIFF
--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -1130,6 +1130,20 @@ Hooks.once("init", () => {
       type: Boolean
     });
 
+    game.settings.register("lootsheetnpc5e", "maxPriceModifier", {
+        name: "Max price modifier percentage",
+        hint: "Increasing this will allow a higher price modifier to be used for merchant sheets",
+        scope: "world",
+        config: true,
+        type: Number,
+        range: {
+            min: 200,
+            max: 10000,
+            step: 100
+        },
+        default: 200
+    });
+
     function chatMessage (speaker, owner, message, item) {
         if (game.settings.get("lootsheetnpc5e", "buyChat")) {
             message =   `

--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -567,6 +567,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
         var html = "<p>Use this slider to increase or decrease the price of all items in this inventory. <i class='fa fa-question-circle' title='This uses a percentage factor where 100% is the current price, 0% is 0, and 200% is double the price.'></i></p>";
         html += '<p><input name="price-modifier-percent" id="price-modifier-percent" type="range" min="0" max="' + maxPriceModifier + '" value="' + priceModifier + '" class="slider"></p>';
         html += '<p><label>Percentage:</label> <input type=number min="0" max="' + maxPriceModifier + '" value="' + priceModifier + '" id="price-modifier-percent-display"></p>';
+        html += '<script>var pmSlider = document.getElementById("price-modifier-percent"); var pmDisplay = document.getElementById("price-modifier-percent-display"); pmDisplay.value = pmSlider.value; pmSlider.onchange = function() { pmDisplay.value = this.value; }; pmDisplay.oninput = function() { pmSlider.value = this.value; };</script>';
 
         let d = new Dialog({
             title: "Price Modifier",

--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -564,6 +564,10 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
 
         var maxPriceModifier = await game.settings.get("lootsheetnpc5e", "maxPriceModifier");
 
+        if (!maxPriceModifier){
+            maxPriceModifier = 200;
+        }
+
         var html = "<p>Use this slider to increase or decrease the price of all items in this inventory. <i class='fa fa-question-circle' title='This uses a percentage factor where 100% is the current price, 0% is 0, and 200% is double the price.'></i></p>";
         html += '<p><input name="price-modifier-percent" id="price-modifier-percent" type="range" min="0" max="' + maxPriceModifier + '" value="' + priceModifier + '" class="slider"></p>';
         html += '<p><label>Percentage:</label> <input type=number min="0" max="' + maxPriceModifier + '" value="' + priceModifier + '" id="price-modifier-percent-display"></p>';

--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -562,10 +562,11 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
 
         priceModifier = Math.round(priceModifier * 100);
 
+        var maxPriceModifier = await game.settings.get("lootsheetnpc5e", "maxPriceModifier");
+
         var html = "<p>Use this slider to increase or decrease the price of all items in this inventory. <i class='fa fa-question-circle' title='This uses a percentage factor where 100% is the current price, 0% is 0, and 200% is double the price.'></i></p>";
-        html += '<p><input name="price-modifier-percent" id="price-modifier-percent" type="range" min="0" max="200" value="'+priceModifier+'" class="slider"></p>';
-        html += '<p><label>Percentage:</label> <input type=number min="0" max="200" value="'+priceModifier+'" id="price-modifier-percent-display"></p>';
-        html += '<script>var pmSlider = document.getElementById("price-modifier-percent"); var pmDisplay = document.getElementById("price-modifier-percent-display"); pmDisplay.value = pmSlider.value; pmSlider.oninput = function() { pmDisplay.value = this.value; }; pmDisplay.oninput = function() { pmSlider.value = this.value; };</script>';
+        html += '<p><input name="price-modifier-percent" id="price-modifier-percent" type="range" min="0" max="' + maxPriceModifier + '" value="' + priceModifier + '" class="slider"></p>';
+        html += '<p><label>Percentage:</label> <input type=number min="0" max="' + maxPriceModifier + '" value="' + priceModifier + '" id="price-modifier-percent-display"></p>';
 
         let d = new Dialog({
             title: "Price Modifier",


### PR DESCRIPTION
Added a module setting to increase max price modifier up to 10000%.

I decided to add this as a module setting, as it's fairly situational, and users lose a _little_ bit of control as this value gets higher.
The module settings slider increases in increments of 100. These can all be tweaked if you want.

In another commit, I have also changed `oninput` to `onchange` for the modifier slider on the merchant sheet, which lets the display update if the slider is moved via scrolling or arrow key input.

Keep up the good work, super useful module!