### PR TITLE
Buy/loot stack fixes

### DIFF
--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -171,7 +171,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
         console.log("Loot Sheet | Merchant settings changed");
 
         const moduleNamespace = "lootsheetnpc5e";
-        const expectedKeys = ["rolltable", "shopQty", "itemQty", "itemQtyLimit", "preventDups"];
+        const expectedKeys = ["rolltable", "shopQty", "itemQty", "itemQtyLimit", "preventDups","clearInventory"];
 
         let targetKey = event.target.name.split('.')[3];
 		
@@ -181,7 +181,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
             return ui.notifications.error(`Error changing stettings for "${targetKey}".`);
         }
 		
-		if (targetKey == "preventDups") {
+		if (targetKey == "preventDups" || targetKey == "clearInventory") {
 			console.log(targetKey + " set to " + event.target.checked);
 			await this.actor.setFlag(moduleNamespace, targetKey, event.target.checked);
 		} else if (event.target.value) {
@@ -210,6 +210,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
         const itemQtyFormula = this.actor.getFlag(moduleNamespace, "itemQty") || "1";
 		const preventDups = this.actor.getFlag(moduleNamespace, "preventDups");
 		const itemQtyLimit = this.actor.getFlag(moduleNamespace, "itemQtyLimit") || "0";
+		const clearInventory = this.actor.getFlag(moduleNamespace, "clearInventory");
 
         let rolltable = game.tables.getName(rolltableName);
         if (!rolltable) {
@@ -218,8 +219,6 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
         }
 
         //console.log(rolltable);
-
-        let clearInventory = game.settings.get("lootsheetnpc5e", "clearInventory");
 
         if (clearInventory) {
             
@@ -1149,15 +1148,6 @@ Hooks.once("init", () => {
             config: true,
             default: true,
             type: Boolean
-    });
-
-    game.settings.register("lootsheetnpc5e", "clearInventory", {
-		  name: "Clear inventory?",
-      hint: "If enabled, all existing items will be removed from the Loot Sheet before adding new items from the rollable table. If disabled, existing items will remain.",
-      scope: "world",
-      config: true,
-      default: false,
-      type: Boolean
     });
 
     game.settings.register("lootsheetnpc5e", "lootCurrency", {

--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -142,9 +142,11 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
 
         // Buy Item
         html.find('.item-buy').click(ev => this._buyItem(ev));
+        html.find('.item-buyall').click(ev => this._buyItem(ev, 1));
 
         // Loot Item
         html.find('.item-loot').click(ev => this._lootItem(ev));
+		html.find('.item-lootall').click(ev => this._lootItem(ev, 1));
 
         // Loot Currency
         html.find('.currency-loot').click(ev => this._lootCoins(ev));
@@ -371,7 +373,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
      * Handle buy item
      * @private
      */
-    _buyItem(event) {
+    _buyItem(event, all=0) {
         event.preventDefault();
         console.log("Loot Sheet | Buy Item clicked");
 
@@ -406,7 +408,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
             processorId: targetGm.id
         };
 
-        if (event.shiftKey) {
+        if (all || event.shiftKey) {
             packet.quantity = item.data.quantity;
         }
 
@@ -434,7 +436,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
      * Handle Loot item
      * @private
      */
-    _lootItem(event) {
+    _lootItem(event, all=0) {
         event.preventDefault();
         console.log("Loot Sheet | Loot Item clicked");
 
@@ -461,7 +463,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
         const targetItem = this.actor.getEmbeddedEntity("OwnedItem", itemId);
 
         const item = {itemId: itemId, quantity: 1};
-        if (event.shiftKey) {
+        if (all || event.shiftKey) {
             item.quantity = targetItem.data.quantity;
         }
 
@@ -1177,7 +1179,7 @@ Hooks.once("init", () => {
                     <h3 class="item-name">${item.name}</h3>
                 </header>
 
-                <div class="card-content">
+                <div class="message-content">
                     <p>` + message + `</p>
                 </div>
             </div>

--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -234,7 +234,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
         shopQtyRoll.roll();
         //console.log(`Loot Sheet | Adding ${shopQtyRoll.result} new items`);
 
-        for (let i = 0; i < shopQtyRoll.result; i++) {
+        for (let i = 0; i < shopQtyRoll.total; i++) {
             const rollResult = rolltable.roll();
             //console.log(rollResult);
             let newItem = null;
@@ -257,7 +257,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
 
             let itemQtyRoll = new Roll(itemQtyFormula);
             itemQtyRoll.roll();
-            console.log(`Loot Sheet | Adding ${itemQtyRoll.result} x ${newItem.name}`)
+            console.log(`Loot Sheet | Adding ${itemQtyRoll.total} x ${newItem.name}`)
 			
             //newItem.data.quantity = itemQtyRoll.result;
 			
@@ -265,11 +265,11 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
 			
 			
 			if (existingItem===null) {
-				if (itemQtyLimit > 0 && Number(itemQtyLimit) < Number(itemQtyRoll.result)) {
+				if (itemQtyLimit > 0 && Number(itemQtyLimit) < Number(itemQtyRoll.total)) {
 					//console.log(itemQtyRoll.result + " exceeds new quantity " + itemQtyLimit + ", limiting");
 					await newItem.update({"data.quantity":itemQtyLimit });
 				} else {
-					await newItem.update({"data.quantity":itemQtyRoll.result });
+					await newItem.update({"data.quantity":itemQtyRoll.total });
 				}
 				
 				
@@ -277,12 +277,12 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
 			}
 			else if (!preventDups)
 			{
-				if (Number(existingItem.data.data.quantity)===Number(itemQtyRoll.result)) {
+				if (Number(existingItem.data.data.quantity)===Number(itemQtyRoll.total)) {
 					i--;
 				} else
 				{
 						
-					let newQty = Number(existingItem.data.data.quantity)+Number(itemQtyRoll.result)
+					let newQty = Number(existingItem.data.data.quantity)+Number(itemQtyRoll.total)
 					if (itemQtyLimit > 0 && Number(itemQtyLimit) < Number(newQty)) {
 						//console.log("Exceeds existing quantity, limiting");
 						await existingItem.update({"data.quantity":itemQtyLimit });

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"name": "lootsheetnpc5e",
 	"title": "Loot Sheet NPC 5e",
 	"description": "This module adds an additional NPC sheet which can be used for loot containers such as chests or shopkeepers.",
-	"version": "2.2.2.NSP",
+	"version": "2.2.4.NSP",
 	"minimumCoreVersion": "0.7.6",
 	"compatibleCoreVersion": "0.7.8",
 	"author": "Jan Ole Peek (ChalkOne), Charles Miller (Kage), NonstickPanda",

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -100,7 +100,7 @@
                         </div>
 						<div class="flexrow">
                             <div class="flexcol"><h4>Prevent Duplicates: </h4></div>
-                            <div class="flexcol"><input name="data.flags.lootsheetnpc5e.allowDups" type="checkbox" data-dtype="boolean" {{#if data.flags.lootsheetnpc5e.allowDups}}checked{{/if}}/></div>
+                            <div class="flexcol"><input name="data.flags.lootsheetnpc5e.preventDups" type="checkbox" data-dtype="boolean" {{#if data.flags.lootsheetnpc5e.preventDups}}checked{{/if}}/></div>
                         </div>
                     </div>
                     <button class="update-inventory" type="update-inventory" name="update-inventory" value="1"><i class="fas fa-balance-scale"></i> Update Shop Inventory</button>

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -102,6 +102,10 @@
                             <div class="flexcol"><h4>Prevent Duplicates: </h4></div>
                             <div class="flexcol"><input name="data.flags.lootsheetnpc5e.preventDups" type="checkbox" data-dtype="boolean" {{#if data.flags.lootsheetnpc5e.preventDups}}checked{{/if}}/></div>
                         </div>
+						<div class="flexrow">
+                            <div class="flexcol"><h4>Clear Inventory: </h4></div>
+                            <div class="flexcol"><input name="data.flags.lootsheetnpc5e.clearInventory" type="checkbox" data-dtype="boolean" {{#if data.flags.lootsheetnpc5e.clearInventory}}checked{{/if}}/></div>
+                        </div>
                     </div>
                     <button class="update-inventory" type="update-inventory" name="update-inventory" value="1"><i class="fas fa-balance-scale"></i> Update Shop Inventory</button>
                 {{/ifeq}}

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -194,10 +194,12 @@
                                         
                                         <div class="item-controls">
                                             {{#ifeq ../../lootsheettype "Loot"}}
+												<a class="item-control item-lootall" title="Loot Stack"><i class="far fa-gem"></i></a>
                                                 <a class="item-control item-loot" title="Loot Item"><i class="fas fa-gem"></i></a>
                                             {{/ifeq}}
 
                                             {{#ifeq ../../lootsheettype "Merchant"}}
+												<a class="item-control item-buyall" title="Buy Stack"><i class="fas fa-coins"></i></a>
                                                 <a class="item-control item-buy" title="Buy Item"><i class="fas fa-dollar-sign"></i></a>
                                             {{/ifeq}}
 


### PR DESCRIPTION
- Buying and looting items now adds to existing stacks rather than creating duplicates.
- Moved Clear Inventory option to sheet level
- Buttons to buy/loot full stack added
- Fix for the prevent dups option and the limit quantity default value.