### PR TITLE
Items only once

### DIFF
--- a/css/lootsheetnpc5e.css
+++ b/css/lootsheetnpc5e.css
@@ -84,7 +84,8 @@
 
 .loot-sheet-npc .gm-settings .sheet-type-info,
 .loot-sheet-npc .gm-settings .permission-info,
-.loot-sheet-npc .gm-settings .merchant-settings-info  {
+.loot-sheet-npc .gm-settings .merchant-settings-info,
+.itemsonce-info  {
   color: #7a7971;
   margin: 6px 6px 6px 24px;
   display: none;

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -102,6 +102,10 @@
                             <div class="flexcol"><h4>Clear Inventory: </h4></div>
                             <div class="flexcol"><input name="data.flags.lootsheetnpc5e.clearInventory" type="checkbox" data-dtype="boolean" {{#if data.flags.lootsheetnpc5e.clearInventory}}checked{{/if}}/></div>
                         </div>
+                        <div class="flexrow">
+                            <div class="flexcol"><h4>Items Only Once:</h4></div>
+                            <div class="flexcol"><input name="data.flags.lootsheetnpc5e.itemOnlyOnce" type="checkbox" data-dtype="boolean" {{#if data.flags.lootsheetnpc5e.itemOnlyOnce}}checked{{/if}}/></div>
+                        </div>
                     </div>
                     <button type="button" class="update-inventory" type="update-inventory" name="update-inventory" value="1"><i class="fas fa-balance-scale"></i> Update Shop Inventory</button>
                 {{/ifeq}}


### PR DESCRIPTION
REQUIRES: https://github.com/jopeek/fvtt-loot-sheet-npc-5e/pull/122 for reduced creation verbosity setting

Added an option to allow items to be only added once. If checked any item in any rolltable is only added once, allowing for faster shop creation.

**Examples:**
Items only once _not_ checked:
![image](https://user-images.githubusercontent.com/18559266/111827022-af9d2100-88e9-11eb-9e0e-e5b97401c2b2.png)

Some items where rolled multiple times, causing less items than desired to be in the shop and some having higher quantities than desired.

Items only once checked:
![image](https://user-images.githubusercontent.com/18559266/111827210-ee32db80-88e9-11eb-9a45-84aada8c2820.png)

We get exactly 9 items with 1 in stock each.

Fixes: https://github.com/jopeek/fvtt-loot-sheet-npc-5e/issues/123