### PR TITLE
Removed floating point decimals from weight view

### DIFF
--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -63,6 +63,10 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
             return (Math.round(basePrice * modifier * 100) / 100).toLocaleString('en') + " gp";
         });
 
+        Handlebars.registerHelper('lootsheetweight', function (weight) {
+            return (Math.round(weight * 1e5) / 1e5).toString();
+        });
+
         const path = "systems/dnd5e/templates/actors/";
         if (!game.user.isGM && this.actor.limited) return path + "limited-sheet.html";
         return "modules/lootsheetnpc5e/template/npc-sheet.html";

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -199,7 +199,7 @@
                                             <i class="fas fa-box" title="Quantity"></i> {{item.data.quantity}}
                                         </div>
                                         <div class="item-weight">
-                                            <i class="fas fa-weight-hanging" title="Weight"></i> {{item.data.weight}}
+                                            <i class="fas fa-weight-hanging" title="Weight"></i> {{lootsheetweight item.data.weight}}
                                         </div>
                                         <div class="item-price">
                                             <i class="fas fa-coins" title="Price (in gp)"></i> {{ lootsheetprice item.data.price ../../priceModifier }}


### PR DESCRIPTION
Fixed a bug where oddly rounded prices would cause floating point decimals to show up in the lootsheet

Fixes: https://github.com/jopeek/fvtt-loot-sheet-npc-5e/issues/131