### PR TITLE
Auto populate loot for tokens

### DIFF
--- a/hooks/onCreateToken.js
+++ b/hooks/onCreateToken.js
@@ -1,3 +1,17 @@
 import populateLoot from '../scripts/populateLoot.js';
 
-let populateLootHook = new populateLoot;
+Hooks.on('ready', async () => {
+    _hookPreTokenCreate();
+});
+
+function _hookPreTokenCreate() {
+  Hooks.on('createToken', (scene, data, options, userId) => {
+    const actor = game.actors.get(data.actorId);
+
+    if (!actor || (data.actorLink)) // Don't for linked token
+      return data;
+
+    let populateLootHook = new populateLoot;
+    populateLootHook.generateLoot(scene, data);
+  });
+}

--- a/hooks/onCreateToken.js
+++ b/hooks/onCreateToken.js
@@ -1,0 +1,3 @@
+import addLoot from '../scripts/addLoot.js';
+
+let customLootHook = new addLoot;

--- a/hooks/onCreateToken.js
+++ b/hooks/onCreateToken.js
@@ -1,3 +1,3 @@
-import addLoot from '../scripts/addLoot.js';
+import populateLoot from '../scripts/populateLoot.js';
 
-let customLootHook = new addLoot;
+let populateLootHook = new populateLoot;

--- a/hooks/onCreateToken.js
+++ b/hooks/onCreateToken.js
@@ -1,7 +1,9 @@
 import populateLoot from '../scripts/populateLoot.js';
 
 Hooks.on('ready', async () => {
-    _hookPreTokenCreate();
+    if(game.settings.get("lootsheetnpc5e","autoPopulateTokens") {
+        _hookPreTokenCreate();
+    }
 });
 
 function _hookPreTokenCreate() {

--- a/hooks/onCreateToken.js
+++ b/hooks/onCreateToken.js
@@ -1,19 +1,16 @@
-import populateLoot from '../scripts/populateLoot.js';
+import {populateLoot} from '../scripts/populateLoot.js';
 
-Hooks.on('ready', async () => {
-    if(game.settings.get("lootsheetnpc5e","autoPopulateTokens") {
-        _hookPreTokenCreate();
-    }
-});
+export let initHooks = () => {
+    Hooks.on('createToken', (scene, data, options, userId) => {
+      
+      if(! game.settings.get("lootsheetnpc5e","autoPopulateTokens")) 
+        return;
+        
+      const actor = game.actors.get(data.actorId);
 
-function _hookPreTokenCreate() {
-  Hooks.on('createToken', (scene, data, options, userId) => {
-    const actor = game.actors.get(data.actorId);
+      if (!actor || (data.actorLink)) // Don't for linked token
+        return data;
 
-    if (!actor || (data.actorLink)) // Don't for linked token
-      return data;
-
-    let populateLootHook = new populateLoot;
-    populateLootHook.generateLoot(scene, data);
-  });
+      populateLoot.generateLoot(scene, data);
+    });
 }

--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -1,5 +1,10 @@
 import ActorSheet5eNPC from "../../systems/dnd5e/module/actor/sheets/npc.js";
 import Item5e from "../../systems/dnd5e/module/item/entity.js";
+import {initHooks} from './hooks/onCreateToken.js';
+
+Hooks.once('init', () => {
+      initHooks();
+});
 
 class LootSheet5eNPCHelper
 {
@@ -1271,7 +1276,7 @@ Hooks.once("init", () => {
         default: false,
         type: Boolean
     });
-    
+
     game.settings.register("lootsheetnpc5e", "fallbackRolltable", {
         name: "fallbackRolltable",
         hint: "If auto populate is active, but no table assigned, this is a fallback table",

--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -1262,6 +1262,24 @@ Hooks.once("init", () => {
         default: 200,
         type: Number
     });
+    
+    game.settings.register("lootsheetnpc5e", "autoPopulateTokens", {
+        name: "Auto populate tokens with loot",
+        hint: "If an actor has a rolltable assigned to it, should the token be populated with the Loot?",
+        scope: "world",
+        config: true,
+        default: false,
+        type: Boolean
+    });
+    
+    game.settings.register("lootsheetnpc5e", "fallbackRolltable", {
+        name: "fallbackRolltable",
+        hint: "If auto populate is active, but no table assigned, this is a fallback table",
+        scope: "world",
+        config: true,
+        default: '',
+        type: String
+    });
 
     function chatMessage(speaker, owner, message, item) {
         if (game.settings.get("lootsheetnpc5e", "buyChat")) {

--- a/module.json
+++ b/module.json
@@ -13,7 +13,7 @@
 	],
 	"styles": ["/css/lootsheetnpc5e.css"],
 	"socket": true,
-	"url": "https://github.com/jopeek/fvtt-loot-sheet-npc-5e",
+	"url": "https://raw.githubusercontent.com/DanielBoettner/fvtt-loot-sheet-npc-5e",
 	"manifest": "https://raw.githubusercontent.com/DanielBoettner/fvtt-loot-sheet-npc-5e/master/module.json",
 	"download": "https://raw.githubusercontent.com/DanielBoettner/fvtt-loot-sheet-npc-5e/archive/master.zip"
 }

--- a/module.json
+++ b/module.json
@@ -13,11 +13,10 @@
 	],
     	"esmodules": [
 		"/lootsheetnpc5e.js",
-		"/hooks/onCreateToken.js"
 	],
 	"styles": ["/css/lootsheetnpc5e.css"],
 	"socket": true,
-	"url": "https://raw.githubusercontent.com/DanielBoettner/fvtt-loot-sheet-npc-5e",
-	"manifest": "https://raw.githubusercontent.com/DanielBoettner/fvtt-loot-sheet-npc-5e/master/module.json",
-	"download": "https://raw.githubusercontent.com/DanielBoettner/fvtt-loot-sheet-npc-5e/archive/master.zip"
+	"url": "https://github.com/jopeek/fvtt-loot-sheet-npc-5e",
+	"manifest": "https://raw.githubusercontent.com/jopeek/fvtt-loot-sheet-npc-5e/master/module.json",
+	"download": "https://github.com/jopeek/fvtt-loot-sheet-npc-5e/archive/master.zip"
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
 	"name": "lootsheetnpc5e",
 	"title": "Loot Sheet NPC 5e",
 	"description": "This module adds an additional NPC sheet which can be used for loot containers such as chests or shopkeepers.",
-	"version": "3.0.3",
+	"version": "3.0.4",
 	"minimumCoreVersion": "0.7.9",
 	"compatibleCoreVersion": "0.7.9",
 	"author": "Jan Ole Peek (ChalkOne), Charles Miller (Kage), NonstickPanda, Kevin Brammer (Striky)",

--- a/module.json
+++ b/module.json
@@ -7,6 +7,10 @@
 	"compatibleCoreVersion": "0.7.9",
 	"author": "Jan Ole Peek (ChalkOne), Charles Miller (Kage), NonstickPanda, Kevin Brammer (Striky)",
 	"systems": ["dnd5e"],
+	"includes": [
+		"./hooks/**",
+		"./scripts/**"
+	],
     	"esmodules": [
 		"/lootsheetnpc5e.js",
 		"/hooks/onCreateToken.js"

--- a/module.json
+++ b/module.json
@@ -14,6 +14,6 @@
 	"styles": ["/css/lootsheetnpc5e.css"],
 	"socket": true,
 	"url": "https://github.com/jopeek/fvtt-loot-sheet-npc-5e",
-	"manifest": "https://raw.githubusercontent.com/jopeek/fvtt-loot-sheet-npc-5e/master/module.json",
-	"download": "https://github.com/jopeek/fvtt-loot-sheet-npc-5e/archive/master.zip"
+	"manifest": "https://raw.githubusercontent.com/DanielBoettner/fvtt-loot-sheet-npc-5e/master/module.json",
+	"download": "https://raw.githubusercontent.com/DanielBoettner/fvtt-loot-sheet-npc-5e/archive/master.zip"
 }

--- a/module.json
+++ b/module.json
@@ -7,7 +7,10 @@
 	"compatibleCoreVersion": "0.7.9",
 	"author": "Jan Ole Peek (ChalkOne), Charles Miller (Kage), NonstickPanda, Kevin Brammer (Striky)",
 	"systems": ["dnd5e"],
-    "esmodules": ["/lootsheetnpc5e.js"],
+    	"esmodules": [
+		"/lootsheetnpc5e.js",
+		"/hooks/onCreateToken.js"
+	],
 	"styles": ["/css/lootsheetnpc5e.css"],
 	"socket": true,
 	"url": "https://github.com/jopeek/fvtt-loot-sheet-npc-5e",

--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
 		"./scripts/**"
 	],
     	"esmodules": [
-		"/lootsheetnpc5e.js",
+		"/lootsheetnpc5e.js"
 	],
 	"styles": ["/css/lootsheetnpc5e.css"],
 	"socket": true,

--- a/onCreateToken.js
+++ b/onCreateToken.js
@@ -1,0 +1,3 @@
+import addLoot from './addLoot.js';
+
+let customLootHook = new addLoot;

--- a/onCreateToken.js
+++ b/onCreateToken.js
@@ -1,3 +1,0 @@
-import addLoot from './addLoot.js';
-
-let customLootHook = new addLoot;

--- a/scripts/populateLoot.js
+++ b/scripts/populateLoot.js
@@ -13,7 +13,7 @@ export class populateLoot {
         const actor = token.actor;
 
         const moduleNamespace = "lootsheetnpc5e";
-				const rolltableName = actor.getFlag(moduleNamespace, "rolltable") || game.settings.get("lootsheetnpc5e","fallbackRolltable");
+	const rolltableName = actor.getFlag(moduleNamespace, "rolltable") || game.settings.get("lootsheetnpc5e","fallbackRolltable");
         const shopQtyFormula = actor.getFlag(moduleNamespace, "shopQty") || "1";
         const itemQtyFormula = actor.getFlag(moduleNamespace, "itemQty") || "1";
         const itemQtyLimit = actor.getFlag(moduleNamespace, "itemQtyLimit") || "0";

--- a/scripts/populateLoot.js
+++ b/scripts/populateLoot.js
@@ -3,35 +3,23 @@ import Item5e from "../../../systems/dnd5e/module/item/entity.js";
 
 export default class populateLoot {
 	constructor() {
-		this.initHooks();
 		return this;
-	}
-	
-	initHooks() {
-		Hooks.on('ready', async () => {
-			this._hookCreateToken();
-		});
-	}
-
-	_hookCreateToken() {
-		Hooks.on('createToken', (scene, data, options, userId) => {
-			const actor = game.actors.get(data.actorId);
-      
-			if (!actor || (data.actorLink)) // Don't for linked token
-		                return data;
-
-			this.generateLoot(scene, data);
-		});
 	}
 
 	async generateLoot(scene, data) {
         //instead of the main actor we want/need the actor of the token.
-	      const tokenId = data._id;
+	const tokenId = data._id;
         const token = canvas.tokens.get(tokenId);
         const actor = token.actor;	
     
         const moduleNamespace = "lootsheetnpc5e";
-        const rolltableName = actor.getFlag(moduleNamespace, "rolltable");
+		
+	if(actor.getFlag(moduleNamespace, "rolltable")){
+		const rolltableName = actor.getFlag(moduleNamespace, "rolltable");
+	} else if (game.settings.get("lootsheetnpc5e","fallbackRolltable")){
+		const rolltableName = game.settings.get("lootsheetnpc5e","fallbackRolltable");
+	}
+		
         const shopQtyFormula = actor.getFlag(moduleNamespace, "shopQty") || "1";
         const itemQtyFormula = actor.getFlag(moduleNamespace, "itemQty") || "1";
         const itemQtyLimit = actor.getFlag(moduleNamespace, "itemQtyLimit") || "0";
@@ -40,13 +28,13 @@ export default class populateLoot {
         const reducedVerbosity = game.settings.get("lootsheetnpc5e", "reduceUpdateVerbosity");
         let shopQtyRoll = new Roll(shopQtyFormula);
         
-        shopQtyRoll.roll();
-       
-        if (!rolltableName) {
+        shopQtyRoll.roll();	
+		
+        if (!rolltableName) {		
           return;
         }
 
-	      let rolltable = game.tables.getName(rolltableName);
+	let rolltable = game.tables.getName(rolltableName);
     
         if (!rolltable) {
             return ui.notifications.error(`No Rollable Table found with name "${rolltableName}".`);

--- a/scripts/populateLoot.js
+++ b/scripts/populateLoot.js
@@ -1,25 +1,19 @@
 import ActorSheet5eNPC from "../../../systems/dnd5e/module/actor/sheets/npc.js";
 import Item5e from "../../../systems/dnd5e/module/item/entity.js";
 
-export default class populateLoot {
+export class populateLoot {
 	constructor() {
 		return this;
 	}
 
-	async generateLoot(scene, data) {
+	static async generateLoot(scene, data) {
         //instead of the main actor we want/need the actor of the token.
-	const tokenId = data._id;
+				const tokenId = data._id;
         const token = canvas.tokens.get(tokenId);
-        const actor = token.actor;	
-    
+        const actor = token.actor;
+
         const moduleNamespace = "lootsheetnpc5e";
-		
-	if(actor.getFlag(moduleNamespace, "rolltable")){
-		const rolltableName = actor.getFlag(moduleNamespace, "rolltable");
-	} else if (game.settings.get("lootsheetnpc5e","fallbackRolltable")){
-		const rolltableName = game.settings.get("lootsheetnpc5e","fallbackRolltable");
-	}
-		
+				const rolltableName = actor.getFlag(moduleNamespace, "rolltable") || game.settings.get("lootsheetnpc5e","fallbackRolltable");
         const shopQtyFormula = actor.getFlag(moduleNamespace, "shopQty") || "1";
         const itemQtyFormula = actor.getFlag(moduleNamespace, "itemQty") || "1";
         const itemQtyLimit = actor.getFlag(moduleNamespace, "itemQtyLimit") || "0";
@@ -27,19 +21,19 @@ export default class populateLoot {
         const itemOnlyOnce = actor.getFlag(moduleNamespace, "itemOnlyOnce");
         const reducedVerbosity = game.settings.get("lootsheetnpc5e", "reduceUpdateVerbosity");
         let shopQtyRoll = new Roll(shopQtyFormula);
-        
-        shopQtyRoll.roll();	
-		
-        if (!rolltableName) {		
+
+        shopQtyRoll.roll();
+
+        if (!rolltableName) {
           return;
         }
 
 	let rolltable = game.tables.getName(rolltableName);
-    
+
         if (!rolltable) {
             return ui.notifications.error(`No Rollable Table found with name "${rolltableName}".`);
         }
-        
+
         if (itemOnlyOnce) {
             if (rolltable.results.length < shopQtyRoll.total)  {
                 return ui.notifications.error(`Cannot create a merchant with ${shopQtyRoll.total} unqiue entries if the rolltable only contains ${rolltable.results.length} items`);
@@ -55,29 +49,29 @@ export default class populateLoot {
             for (let i = 0; i < shopQtyRoll.total; i++) {
                 const rollResult = rolltable.roll();
                 let newItem = null;
-    
+
                 if (rollResult.results[0].collection === "Item") {
                     newItem = game.items.get(rollResult.results[0].resultId);
                 } else {
                     const items = game.packs.get(rollResult.results[0].collection);
                     newItem = await items.getEntity(rollResult.results[0].resultId);
                 }
-              
+
                 if (!newItem || newItem === null) {
                     return;
                 }
-                
+
                 if (newItem.type === "spell") {
                     newItem = await Item5e.createScrollFromSpell(newItem)
                 }
 
                 let itemQtyRoll = new Roll(itemQtyFormula);
                 itemQtyRoll.roll();
-                
+
                 console.log(`Loot Sheet | Adding ${itemQtyRoll.total} x ${newItem.name}`)
-    
+
                 let existingItem = actor.items.find(item => item.data.name == newItem.name);
-       
+
                 if (existingItem === null) {
                     await actor.createEmbeddedEntity("OwnedItem", newItem);
                     console.log(`Loot Sheet | ${newItem.name} does not exist.`);
@@ -92,16 +86,16 @@ export default class populateLoot {
                     }
                 } else {
                     console.log(`Loot Sheet | Item ${newItem.name} exists.`);
-                    
+
                     let newQty = Number(existingItem.data.data.quantity) + Number(itemQtyRoll.total);
-        
+
                     if (itemQtyLimit > 0 && Number(itemQtyLimit) === Number(existingItem.data.data.quantity)) {
                       if (!reducedVerbosity) ui.notifications.info(`${newItem.name} already at maximum quantity (${itemQtyLimit}).`);
                     }
                     else if (itemQtyLimit > 0 && Number(itemQtyLimit) < Number(newQty)) {
                     //console.log("Exceeds existing quantity, limiting");
                       await existingItem.update({ "data.quantity": itemQtyLimit });
-                    
+
                       if (!reducedVerbosity) ui.notifications.info(`Added additional quantity to ${newItem.name} to the specified maximum of ${itemQtyLimit}.`);
                     } else {
                       await existingItem.update({ "data.quantity": newQty });
@@ -119,19 +113,19 @@ export default class populateLoot {
                 let numberOfEntries = rolltable.data.results[index].weight
                 for (let i = 0; i < numberOfEntries; i++) {
                     rolltableIndexes.push(index);
-                }     
+                }
             }
-            
+
             // Shuffle the list of indexes
             var currentIndex = rolltableIndexes.length, temporaryValue, randomIndex;
-      
+
             // While there remain elements to shuffle...
             while (0 !== currentIndex) {
-        
+
                 // Pick a remaining element...
                 randomIndex = Math.floor(Math.random() * currentIndex);
                 currentIndex -= 1;
-            
+
                 // And swap it with the current element.
                 temporaryValue = rolltableIndexes[currentIndex];
                 rolltableIndexes[currentIndex] = rolltableIndexes[randomIndex];
@@ -149,7 +143,7 @@ export default class populateLoot {
                 let usedEntries = rolltableIndexes.slice(0, shopQtyRoll.total + numberOfAdditionalItems);
                 // console.log(`Distinct: ${usedEntries}`);
                 let distinctEntris = [...new Set(usedEntries)];
-                
+
                 if (distinctEntris.length < shopQtyRoll.total) {
                     numberOfAdditionalItems++;
                     // console.log(`numberOfAdditionalItems: ${numberOfAdditionalItems}`);
@@ -160,7 +154,7 @@ export default class populateLoot {
                 // console.log(`indexesToUse: ${indexesToUse}`)
                 break;
             }
-      
+
             for (const index of indexesToUse)
             {
                 let itemQtyRoll = new Roll(itemQtyFormula);

--- a/scripts/populateLoot.js
+++ b/scripts/populateLoot.js
@@ -1,0 +1,212 @@
+import ActorSheet5eNPC from "../../../systems/dnd5e/module/actor/sheets/npc.js";
+import Item5e from "../../../systems/dnd5e/module/item/entity.js";
+
+export default class populateLoot {
+	constructor() {
+		this.initHooks();
+		return this;
+	}
+	
+	initHooks() {
+		Hooks.on('ready', async () => {
+			this._hookCreateToken();
+		});
+	}
+
+	_hookCreateToken() {
+		Hooks.on('createToken', (scene, data, options, userId) => {
+			const actor = game.actors.get(data.actorId);
+      
+			if (!actor || (data.actorLink)) // Don't for linked token
+		                return data;
+
+			this.generateLoot(scene, data);
+		});
+	}
+
+	async generateLoot(scene, data) {
+        //instead of the main actor we want/need the actor of the token.
+	      const tokenId = data._id;
+        const token = canvas.tokens.get(tokenId);
+        const actor = token.actor;	
+    
+        const moduleNamespace = "lootsheetnpc5e";
+        const rolltableName = actor.getFlag(moduleNamespace, "rolltable");
+        const shopQtyFormula = actor.getFlag(moduleNamespace, "shopQty") || "1";
+        const itemQtyFormula = actor.getFlag(moduleNamespace, "itemQty") || "1";
+        const itemQtyLimit = actor.getFlag(moduleNamespace, "itemQtyLimit") || "0";
+        const clearInventory = actor.getFlag(moduleNamespace, "clearInventory");
+        const itemOnlyOnce = actor.getFlag(moduleNamespace, "itemOnlyOnce");
+        const reducedVerbosity = game.settings.get("lootsheetnpc5e", "reduceUpdateVerbosity");
+        let shopQtyRoll = new Roll(shopQtyFormula);
+        
+        shopQtyRoll.roll();
+       
+        if (!rolltableName) {
+          return;
+        }
+
+	      let rolltable = game.tables.getName(rolltableName);
+    
+        if (!rolltable) {
+            return ui.notifications.error(`No Rollable Table found with name "${rolltableName}".`);
+        }
+        
+        if (itemOnlyOnce) {
+            if (rolltable.results.length < shopQtyRoll.total)  {
+                return ui.notifications.error(`Cannot create a merchant with ${shopQtyRoll.total} unqiue entries if the rolltable only contains ${rolltable.results.length} items`);
+            }
+        }
+
+        if (clearInventory) {
+            let currentItems = actor.data.items.map(i => i._id);
+            await actor.deleteEmbeddedEntity("OwnedItem", currentItems);
+        }
+
+        if (!itemOnlyOnce) {
+            for (let i = 0; i < shopQtyRoll.total; i++) {
+                const rollResult = rolltable.roll();
+                let newItem = null;
+    
+                if (rollResult.results[0].collection === "Item") {
+                    newItem = game.items.get(rollResult.results[0].resultId);
+                } else {
+                    const items = game.packs.get(rollResult.results[0].collection);
+                    newItem = await items.getEntity(rollResult.results[0].resultId);
+                }
+              
+                if (!newItem || newItem === null) {
+                    return;
+                }
+                
+                if (newItem.type === "spell") {
+                    newItem = await Item5e.createScrollFromSpell(newItem)
+                }
+
+                let itemQtyRoll = new Roll(itemQtyFormula);
+                itemQtyRoll.roll();
+                
+                console.log(`Loot Sheet | Adding ${itemQtyRoll.total} x ${newItem.name}`)
+    
+                let existingItem = actor.items.find(item => item.data.name == newItem.name);
+       
+                if (existingItem === null) {
+                    await actor.createEmbeddedEntity("OwnedItem", newItem);
+                    console.log(`Loot Sheet | ${newItem.name} does not exist.`);
+                    existingItem = await actor.items.find(item => item.data.name == newItem.name);
+
+                    if (itemQtyLimit > 0 && Number(itemQtyLimit) < Number(itemQtyRoll.total)) {
+                        await existingItem.update({ "data.quantity": itemQtyLimit });
+                        if (!reducedVerbosity) ui.notifications.info(`Added new ${itemQtyLimit} x ${newItem.name}.`);
+                    } else {
+                        await existingItem.update({ "data.quantity": itemQtyRoll.total });
+                        if (!reducedVerbosity) ui.notifications.info(`Added new ${itemQtyRoll.total} x ${newItem.name}.`);
+                    }
+                } else {
+                    console.log(`Loot Sheet | Item ${newItem.name} exists.`);
+                    
+                    let newQty = Number(existingItem.data.data.quantity) + Number(itemQtyRoll.total);
+        
+                    if (itemQtyLimit > 0 && Number(itemQtyLimit) === Number(existingItem.data.data.quantity)) {
+                      if (!reducedVerbosity) ui.notifications.info(`${newItem.name} already at maximum quantity (${itemQtyLimit}).`);
+                    }
+                    else if (itemQtyLimit > 0 && Number(itemQtyLimit) < Number(newQty)) {
+                    //console.log("Exceeds existing quantity, limiting");
+                      await existingItem.update({ "data.quantity": itemQtyLimit });
+                    
+                      if (!reducedVerbosity) ui.notifications.info(`Added additional quantity to ${newItem.name} to the specified maximum of ${itemQtyLimit}.`);
+                    } else {
+                      await existingItem.update({ "data.quantity": newQty });
+                      if (!reducedVerbosity) ui.notifications.info(`Added additional ${itemQtyRoll.total} quantity to ${newItem.name}.`);
+                    }
+                }
+            }
+        } else {
+            // Get a list which contains indexes of all possible results
+
+            const rolltableIndexes = []
+
+            // Add one entry for each weight an item has
+            for (let index in [...Array(rolltable.results.length).keys()]) {
+                let numberOfEntries = rolltable.data.results[index].weight
+                for (let i = 0; i < numberOfEntries; i++) {
+                    rolltableIndexes.push(index);
+                }     
+            }
+            
+            // Shuffle the list of indexes
+            var currentIndex = rolltableIndexes.length, temporaryValue, randomIndex;
+      
+            // While there remain elements to shuffle...
+            while (0 !== currentIndex) {
+        
+                // Pick a remaining element...
+                randomIndex = Math.floor(Math.random() * currentIndex);
+                currentIndex -= 1;
+            
+                // And swap it with the current element.
+                temporaryValue = rolltableIndexes[currentIndex];
+                rolltableIndexes[currentIndex] = rolltableIndexes[randomIndex];
+                rolltableIndexes[randomIndex] = temporaryValue;
+            }
+
+            // console.log(`Rollables: ${rolltableIndexes}`)
+
+            let indexesToUse = [];
+            let numberOfAdditionalItems = 0;
+            // Get the first N entries from our shuffled list. Those are the indexes of the items in the roll table we want to add
+            // But because we added multiple entries per index to account for weighting, we need to increase our list length until we got enough unique items
+            while (true)
+            {
+                let usedEntries = rolltableIndexes.slice(0, shopQtyRoll.total + numberOfAdditionalItems);
+                // console.log(`Distinct: ${usedEntries}`);
+                let distinctEntris = [...new Set(usedEntries)];
+                
+                if (distinctEntris.length < shopQtyRoll.total) {
+                    numberOfAdditionalItems++;
+                    // console.log(`numberOfAdditionalItems: ${numberOfAdditionalItems}`);
+                    continue;
+                }
+
+                indexesToUse = distinctEntris
+                // console.log(`indexesToUse: ${indexesToUse}`)
+                break;
+            }
+      
+            for (const index of indexesToUse)
+            {
+                let itemQtyRoll = new Roll(itemQtyFormula);
+                itemQtyRoll.roll();
+
+                let newItem = null
+
+                if (rolltable.results[index].collection === "Item") {
+                    newItem = game.items.get(rolltable.results[index].resultId);
+                }
+                else {
+                    //Try to find it in the compendium
+                    const items = game.packs.get(rolltable.results[index].collection);
+                    newItem = await items.getEntity(rolltable.results[index].resultId);
+                }
+                if (!newItem || newItem === null) {
+                    return ui.notifications.error(`No item found "${rolltable.results[index].resultId}".`);
+                }
+
+                if (newItem.type === "spell") {
+                    newItem = await Item5e.createScrollFromSpell(newItem)
+                }
+
+                await item.createEmbeddedEntity("OwnedItem", newItem);
+                let existingItem = actor.items.find(item => item.data.name == newItem.name);
+
+                if (itemQtyLimit > 0 && Number(itemQtyLimit) < Number(itemQtyRoll.total)) {
+                    await existingItem.update({ "data.quantity": itemQtyLimit });
+                    if (!reducedVerbosity) ui.notifications.info(`Added new ${itemQtyLimit} x ${newItem.name}.`);
+                } else {
+                    await existingItem.update({ "data.quantity": itemQtyRoll.total });
+                    if (!reducedVerbosity) ui.notifications.info(`Added new ${itemQtyRoll.total} x ${newItem.name}.`);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR would add the following things:

> Autopopulation of Loot to a token(actor) with either _rolltable_ set on the actor or a fallback table from the game settings.

* Hook on "createToken"
* game setting to enable auto populate
* game setting for a fallback table if non is set on the actor.

Please feel free to let me know if this is beyond the scope of this module.
I can create a separate module if needed. But as it heavily builds on this module I thought I give it a try.

If merged, the specific "onCreateToken.js" could be renamed to "defaultHooks.js" (example).
To get all hooks currently registered in "lootsheetnpc5e.js"
