### PR TITLE
Fix Nullish check in _hackydistributeCoins

### DIFF
--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -849,7 +849,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
                 //console.log("Loot Sheet | player", player);
                 let actor = game.actors.get(player.data.character);
                 //console.log("Loot Sheet | actor", actor);
-                if (actor !== null && (player.data.role === 1 || player.data.role === 2)) observers.push(actor);
+                if (actor != null && (player.data.role === 1 || player.data.role === 2)) observers.push(actor);
             }
         }
 
@@ -1551,7 +1551,7 @@ Hooks.once("init", () => {
                 //console.log("Loot Sheet | player", player);
                 let actor = game.actors.get(player.data.character);
                 //console.log("Loot Sheet | actor", actor);
-                if (actor !== null && (player.data.role === 1 || player.data.role === 2)) observers.push(actor);
+                if (actor != null && (player.data.role === 1 || player.data.role === 2)) observers.push(actor);
             }
         }
 


### PR DESCRIPTION
`actor !== null` was true if `actor` was `undefined` - Causing incorrect splitting, and an NPE when getting the Actor's currency on line 884