### PR TITLE
Prefer "create..." return value over searching for the newly-created item

### DIFF
--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -334,9 +334,10 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
                 let existingItem = this.actor.items.find(item => item.data.name == newItem.name);
                 
                 if (existingItem === undefined) {
-                    await this.actor.createEmbeddedDocuments("Item", [newItem.toObject()]);
                     console.log(`Loot Sheet | ${newItem.name} does not exist.`);
-                    existingItem = this.actor.items.find(item => item.data.name == newItem.name);
+
+                    const createdItems = await this.actor.createEmbeddedDocuments("Item", [newItem.toObject()]);
+                    existingItem = createdItems[0];
 
                     if (itemQtyLimit > 0 && Number(itemQtyLimit) < Number(itemQtyRoll.total)) {
                         await existingItem.update({ "data.quantity": itemQtyLimit });


### PR DESCRIPTION
As we receive a reference to all items created by the `actor.createEmbeddedDocuments` call, we can use this reference rather than search for the item by name. This fixes a (very rare) timing bug, and has the added benefit of improving performance.

---

The timing bug in question:

![image](https://user-images.githubusercontent.com/25264887/135455047-74f0f8b2-2a79-4e78-9e42-8ffb1f0702fc.png)

Here we can see that the "Created Item" log comes _after_ we have already attempted to look for our newly-created item, i.e., the item did not exist in `actor.items` when we searched for it. Fwiw I have no idea why this happens; I assume some very minor timing issue in Foundry itself.