### PR TITLE
Fix currency issues in latest release

### DIFF
--- a/lootsheetnpc5e.js
+++ b/lootsheetnpc5e.js
@@ -178,6 +178,7 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
         sheetData.rolltables = game.tables.entities;
         sheetData.lootCurrency = game.settings.get("lootsheetnpc5e", "lootCurrency");
         sheetData.lootAll = game.settings.get("lootsheetnpc5e", "lootAll");
+        sheetData.data.currency = LootSheet5eNPCHelper.convertCurrencyFromObject(sheetData.data.currency);
 
         // Return data for rendering
         return sheetData;
@@ -1183,9 +1184,9 @@ class LootSheet5eNPC extends ActorSheet5eNPC {
         let currencySplit = duplicate(LootSheet5eNPCHelper.convertCurrencyFromObject(actorData.data.currency));
         for (let c in currencySplit) {
             if (observers.length)
-                if (currencySplit[c].value != null) currencySplit[c].value = Math.floor(currencySplit[c].value / observers.length);
+                if (currencySplit[c] != null) currencySplit[c] = Math.floor(currencySplit[c] / observers.length);
             else
-                currencySplit[c].value = 0
+                currencySplit[c] = 0
         }
 
         let loot = {}

--- a/template/npc-sheet.html
+++ b/template/npc-sheet.html
@@ -119,7 +119,7 @@
                     {{#each actor.flags.loot.currency as |c i|}}
                         <li class="denomination {{i}}">
                             <label>{{lookup (lookup ../config.currencies i) "label"}}:</label>
-                            <span class="denomination-value">{{c.value}} each</span>
+                            <span class="denomination-value">{{c}} each</span>
                         </li>
                     {{/each}}
                 </ol>
@@ -151,7 +151,7 @@
                                 {{#each data.currency as |c i|}}
                                 <span>
                                     <label class="denomination {{i}}">{{lookup (lookup ../config.currencies i) "label"}}</label>
-                                    <input type="text" name="data.currency.{{i}}.value" value="{{c.value}}" data-dtype="{{c.type}}"/>
+                                    <input type="text" name="data.currency.{{i}}" value="{{c}}" data-dtype="number"/>
                                 </span>
                                 {{/each}}
                                 {{#ifeq lootsheettype "Loot"}}


### PR DESCRIPTION
Due to two separate conflicting PRs that came into the loot sheet repo, currency was terribly broken. This PR corrects the issues and gets currency working again.