### PR TITLE
convertTokens remove deprecated permission refs

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
 	"name": "lootsheetnpc5e",
 	"title": "LootsheetNPC5e",
 	"description": "This module adds an additional NPC sheet. It can be used for loot containers such as chests or shopkeepers.",
-	"version": "3.5.7",
+	"version": "3.5.8",
 	"manifestPlusVersion": "1.2.0",
 	"minimumCoreVersion": "0.9.0",
 	"compatibleCoreVersion": "9.249",
@@ -81,5 +81,5 @@
 	"socket": true,
 	"url": "https://github.com/jopeek/fvtt-loot-sheet-npc-5e",
 	"manifest": "https://raw.githubusercontent.com/jopeek/fvtt-loot-sheet-npc-5e/master/src/module.json",
-	"download": "https://github.com/jopeek/fvtt-loot-sheet-npc-5e/releases/download/v3.5.7/lootsheetnpc5e.zip"
+	"download": "https://github.com/jopeek/fvtt-loot-sheet-npc-5e/releases/download/v3.5.8/lootsheetnpc5e.zip"
 }

--- a/src/modules/API.js
+++ b/src/modules/API.js
@@ -95,7 +95,7 @@ class API {
                 actor: {
                     flags: {
                         lootsheetnpc5e: {
-                            playersPermission: CONST.ENTITY_PERMISSIONS.OBSERVER,
+                            playersPermission: CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER,
                         },
                     },
                 },
@@ -133,7 +133,7 @@ class API {
         options = {},
         verbose = false
     ) {
-        const tokenstack = (tokens) ? (tokens.length >= 0) ? tokens : [tokens] : canvas.tokens.controlled;
+        const tokenstack = (tokens) ? (tokens.length > 0) ? tokens : [tokens] : canvas.tokens.controlled;
 
         let response = API._response(200, 'success');
 
@@ -207,7 +207,7 @@ class API {
     ) {
         if (!game.user.isGM) return;
 
-        const tokenstack = (tokens) ? (tokens.length >= 0) ? tokens : [tokens] : canvas.tokens.controlled;
+        const tokenstack = (tokens) ? (tokens.length > 0) ? tokens : [tokens] : canvas.tokens.controlled;
 
         let permissions = false,
             response = API._response(200, 'success'),
@@ -215,7 +215,7 @@ class API {
             tokenData = { actorData: { permission: {} } };
 
         for (let token of tokenstack) {
-            let permissions = PermissionHelper._updatedUserPermissions(token, CONST.ENTITY_PERMISSIONS.OBSERVER, players);
+            let permissions = PermissionHelper._updatedUserPermissions(token, CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER, players);
             tokenData.actorData.permission = permissions,
                 responseData[token.uuid] = tokenData.actorData.permission;
             await token.document.update(tokenData);
@@ -259,7 +259,7 @@ class API {
     /**
      * Use the PermissionHelper to update the users permissions for the token
      *
-     * @param {Token5e} token
+     * @param {Token} token
      * @param {number|null} permission enum
      *
      * @return {object} reponse object
@@ -281,12 +281,17 @@ class API {
         return response;
     }
 
+    /**
+     * @summary get the filter rules that exist for the loot sheet seeder
+     * @returns {object}
+     */
     static getRegisteredCustomRules() {
         return game.settings.get(MODULE.ns, MODULE.settings.keys.lootseeder.ruleset);
     }
 
     /**
      * Update the lootseeder custom rules
+     *
      * Expects a {lootseederRule} object
      *
      * @param {lootseederRule} rule
@@ -302,9 +307,26 @@ class API {
     /**
      *
      * @param {boolean} state
+     * @deprecated use toggleSeederState instead
      */
-    static switchPopulatorState(state) {
+    static switchPopulatorState(state = null) {
+        return this.toggleSeederState(state);
+    }
+
+    /**
+     * @param {boolean} state
+     *
+     *
+     * @returns {boolean}
+     */
+    static toggleSeederState(state = null) {
+        if (state === null) {
+            state = !game.settings.get(MODULE.ns, MODULE.settings.keys.lootseeder.autoSeedTokens);
+        }
+
         game.settings.set(MODULE.ns, MODULE.settings.keys.lootseeder.autoSeedTokens, state);
+
+        return game.settings.get(MODULE.ns, MODULE.settings.keys.lootseeder.autoSeedTokens);
     }
 
     /**
@@ -328,7 +350,7 @@ class API {
      * @private
      */
     static _verbose(data = '') {
-        console.log('|--- ' + MODULE.ns + ' API (verbose output) ---|', data, '|--- ' + MODULE.ns + ' API (/verbose output)---|');
+        console.log(`${MODULE.ns} | API (verbose output) | data, '|--- ' + MODULE.ns + ' API (/verbose output)---|`);
     }
 
     static _response(code, msg = '', data = {}, error = false) {

--- a/src/modules/apps/sheets/LootsheetNPC5e.js
+++ b/src/modules/apps/sheets/LootsheetNPC5e.js
@@ -99,7 +99,7 @@ export class LootSheetNPC5e extends ActorSheet5eNPC {
         sheetData.isGM = (game.user.isGM) ? true : false;
         sheetData.items = sheetDataActorItems;
         sheetData.interactingActor = game.user?.character?.name || "No Character selected";
-        sheetData.interactingActorFunds = {currency: game.user?.character?.data?.data?.currency || [] };
+        sheetData.interactingActorFunds = {currency: CurrencyHelper.handleActorCurrency(game.user?.character?.data?.data?.currency) || [] };
         sheetData.totalItems = sheetDataActorItems.length;
         sheetData.totalWeight = totals.weight.toLocaleString('en');
         sheetData.totalPrice = totals.price.toLocaleString('en') + " gp";

--- a/src/modules/helper/HandlebarsHelper.js
+++ b/src/modules/helper/HandlebarsHelper.js
@@ -182,12 +182,12 @@ export class HandlebarsHelper {
      * @description Calculate the price of an item after applying the cost modifier
      *
      * @param {number} cost
-     * @param {number} modifier
+     * @param {number} priceModifier
      *
      * @return {number}
      */
-    static lootsheetPrice(basePrice, modifier = 1, currency = true) {
-        const price = (Math.round(basePrice * modifier * 100) / 100),
+    static lootsheetPrice(basePrice, priceModifier = 1, currency = true) {
+        const price = parseFloat(((basePrice * priceModifier * 1000) / 1000).toFixed(5)),
             suffix = currency ? " GP" : "";
 
         return price + suffix;

--- a/src/modules/helper/LootSheetNPC5eHelper.js
+++ b/src/modules/helper/LootSheetNPC5eHelper.js
@@ -131,7 +131,7 @@ class LootSheetNPC5eHelper {
                             id: tradeItem.dataset.id,
                             data: {
                                 quantity: parseInt(tradeItem.dataset.quantity),
-                                price: parseInt(tradeItem.dataset.price)
+                                price: parseFloat(tradeItem.dataset.price)
                             }
                         },
                     };

--- a/src/modules/helper/PermissionHelper.js
+++ b/src/modules/helper/PermissionHelper.js
@@ -100,7 +100,7 @@ export class PermissionHelper {
      */
     static _updatedUserPermissions(
         token = canvas.tokens.controlled[0],
-        level = CONST.ENTITY_PERMISSIONS.OBSERVER || 0,
+        level = CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER || 0,
         lootingUsers = this.getPlayers()
     ) {
         let currentPermissions = duplicate(token.actor.data.permission);

--- a/src/modules/helper/TradeHelper.js
+++ b/src/modules/helper/TradeHelper.js
@@ -367,8 +367,8 @@ export class TradeHelper {
             "cp": CONFIG.DND5E.currencies.cp.conversion.each
         };
 
-        let buyerFunds = duplicate(buyer.data.data.currency),
-            sellerFunds = duplicate(seller.data.data.currency),
+        let buyerFunds = CurrencyHelper.handleActorCurrency(buyer.data.data.currency),
+            sellerFunds = CurrencyHelper.handleActorCurrency(seller.data.data.currency),
             itemCost = {
                 "pp": itemCostInGold / rates.gp,
                 "gp": itemCostInGold

--- a/src/modules/helper/TradeHelper.js
+++ b/src/modules/helper/TradeHelper.js
@@ -132,11 +132,11 @@ export class TradeHelper {
         let moved = false;
         quantity = (soldItem.data.data.quantity < quantity) ? parseInt(soldItem.data.data.quantity) : parseInt(quantity);
 
-        let itemCostInGold = Math.round(((soldItem.data.data.price * priceModifier * 100) / 100) * quantity),
+        let itemCostInGold = this._getItemPriceInGold(soldItem, priceModifier),
             successfullTransaction = await this._updateFunds(seller, buyer, itemCostInGold);
         if (!successfullTransaction) return false;
         moved = await ItemHelper.moveItemsToDestination(seller, buyer, [{ id: itemId, data: { data: { quantity: quantity } } }]);
-        options.type="buy";
+        options.type = "buy";
         options.priceModifier = priceModifier;
         ChatHelper.tradeChatMessage(seller, buyer, moved, options);
     }
@@ -151,12 +151,12 @@ export class TradeHelper {
      *
      * @returns {Promise<boolean>}
      */
-     static async distributeCurrency(source, destination, options = { verbose: true }) {
+    static async distributeCurrency(source, destination, options = { verbose: true }) {
         const eligables = PermissionHelper.getEligableActors(source),
             currency = CurrencyHelper.handleActorCurrency(source.data.data.currency),
             shares = CurrencyHelper.getSharesAndRemainder(currency, eligables.length);
 
-        let splits = {shares: shares.currencyShares, receivers : []};
+        let splits = { shares: shares.currencyShares, receivers: [] };
 
         if (options.verbose) {
             let cmsg = `${MODULE.ns} | distributeCurrency |`;
@@ -182,11 +182,11 @@ export class TradeHelper {
                 newCurrency[c] = parseInt(playerCurrency[c] || 0) + shares.currencyShares[c];
             }
 
-            await playerCharacter.update({'data.currency': newCurrency});
+            await playerCharacter.update({ 'data.currency': newCurrency });
         }
 
         // set source funds to 0
-        source.update({"data.currency": { cp: 0, ep: 0, gp: 0, pp: 0, sp: 0 }});
+        source.update({ "data.currency": { cp: 0, ep: 0, gp: 0, pp: 0, sp: 0 } });
 
         // update the chat
         if (!options.chatOutPut) return;
@@ -210,7 +210,7 @@ export class TradeHelper {
      * @since 1.0.1
      * @inheritdoc
      */
-    static async lootCurrency(source, destination, options = {chatOutPut: true}) {
+    static async lootCurrency(source, destination, options = { chatOutPut: true }) {
         const actorData = source.data;
         let sheetCurrency = duplicate(actorData.data.currency),
             originalCurrency = duplicate(destination.data.data.currency),
@@ -226,10 +226,10 @@ export class TradeHelper {
         }
 
         // set the destination currency to the new currency
-        destination.update({'data.currency': newCurrency});
+        destination.update({ 'data.currency': newCurrency });
 
         // set source funds to 0
-        source.update({"data.currency": { cp: 0, ep: 0, gp: 0, pp: 0, sp: 0 }});
+        source.update({ "data.currency": { cp: 0, ep: 0, gp: 0, pp: 0, sp: 0 } });
 
         // update the chat
         if (!options.chatOutPut) return;
@@ -288,7 +288,7 @@ export class TradeHelper {
         const freeTradeTypes = ['loot', 'give'];
         let successfullTransaction = true;
 
-        if(!freeTradeTypes.includes(tradeType)){
+        if (!freeTradeTypes.includes(tradeType)) {
             successfullTransaction = await this._updateFunds(source, destination, tradeSum, options);
         }
 
@@ -318,16 +318,28 @@ export class TradeHelper {
         for (const [key, item] of items.entries()) {
             if (!source.items.find(i => i.id == item.id)) {
                 if (options?.verbose)
-                    console.log(`${MODULE.ns} | ${this._prepareTrade.name} | Removed item "${item.name}" (id: ${item.id}) from trade. Item not found in inventory of the source actor.`);
+                    console.log(`${MODULE.ns} | _prepareTrade | Removed item "${item.name}" (id: ${item.id}) from trade. Item not found in inventory of the source actor.`);
                 delete items[key];
                 continue;
             }
             // Add item price to the total sum of the trade
-            tradeSum += Math.round(((item.data.data.price * priceModifier * 100) / 100) * item.data.data.quantity);
+            tradeSum += this._getItemPrice(item, priceModifier);
             if (options?.verbose) console.log(`${MODULE.ns} | ${this._prepareTrade.name} | tradeSum updated to: `);
         }
 
-        return {items: items, tradeSum: tradeSum};
+        return { items: items, tradeSum: tradeSum };
+    }
+
+    /**
+     * @summary Get the items price in gold
+     *
+     * @param {Item} item
+     * @param {number} priceModifier
+     *
+     * @returns {number} price - a float with 5 decimals
+     */
+    static _getItemPriceInGold(item, priceModifier) {
+        return parseFloat(((item.data.data.price * priceModifier * 1000) / 1000 * item.data.data.quantity).toFixed(5));
     }
 
     /**
@@ -412,7 +424,7 @@ export class TradeHelper {
             buyerFunds = this._updateConvertCurrency(buyerFunds, fundsAsPlatinum.buyer);
             sellerFunds = this._updateConvertCurrency(sellerFunds, fundsAsPlatinum.seller);
         } else {
-            if(buyerFunds.gp >= itemCost.gp) {
+            if (buyerFunds.gp >= itemCost.gp) {
                 buyerFunds.gp -= itemCost.gp;
                 sellerFunds.gp += itemCost.gp;
             } else {
@@ -423,7 +435,7 @@ export class TradeHelper {
             buyerFunds = this._smoothenFunds(buyerFunds, compensation, rates);
             sellerFunds = this._smoothenFunds(sellerFunds, compensation, rates);
         }
-        return {buyerFunds: buyerFunds, sellerFunds: sellerFunds};
+        return { buyerFunds: buyerFunds, sellerFunds: sellerFunds };
     }
 
     /**
@@ -470,10 +482,10 @@ export class TradeHelper {
      *
      * @returns {object}
      */
-    static _smoothenFunds(funds, compensation, rates ){
+    static _smoothenFunds(funds, compensation, rates) {
         for (let currency in funds) {
-            let current = funds[currency].toFixed(5),
-                currentPart = (current % 1).toFixed(5),
+            let current = funds[currency].toFixed(8),
+                currentPart = (current % 1).toFixed(8),
                 currentInt = Math.round(current - currentPart),
                 compCurrency = compensation[currency];
 

--- a/src/modules/hooks/LootsheetNPC5eHooks.js
+++ b/src/modules/hooks/LootsheetNPC5eHooks.js
@@ -190,8 +190,9 @@ export class LootsheetNPC5eHooks {
             lsnGMButtonMakeObservable.dataset.action = "makeObservable";
             lsnGMButtonMakeObservable.addEventListener('click', async (e) => {
                 if (game.user.isGM) {
+                    ui.notifications.info(`Lootsheet: Converting token(s) to lootable.`);
                     const api = game.modules.get("lootsheetnpc5e").public.API;
-                    await api.makeObservable();
+                    await api.convertTokens();
                 }
             });
 

--- a/src/styles/partials/trade.less
+++ b/src/styles/partials/trade.less
@@ -11,7 +11,7 @@
                 "TOKENINVENTORY STAGE PLAYERINVENTORY"
                 "TINFO ACTIONS PINFO";
             grid-template-columns: 1fr 200px 1fr;
-            grid-template-rows: 42vh 8vh;
+            grid-template-rows: 42vh 11vh;
             margin-top: 0.1em;
             width: 100%;
             align-items: start;
@@ -34,7 +34,7 @@
                 justify-content: flex-start;
                 overflow-y: scroll;
                 flex-wrap: wrap;
-                height: 42vh;
+                height: 40vh;
 
                 align-content: flex-start;
 
@@ -83,12 +83,12 @@
 
             .token-info {
                 grid-area: TINFO;
-                align-self: self-end;
+                align-self: self-start;
             }
 
             .player-info {
                 grid-area: PINFO;
-                align-self: self-end;
+                align-self: self-start;
             }
 
             .stage {

--- a/src/templates/partials/welcomeScreen/misc.hbs
+++ b/src/templates/partials/welcomeScreen/misc.hbs
@@ -1,5 +1,5 @@
 <article class="tab" data-tab="misc" data-group="ws-sections">
-    <h1>LootsheetNPC5e <em><small>v3.5.0</small></em></h1>
+    <h1>LootsheetNPC5e <em><small>v3.5.8</small></em></h1>
     <h2>Thank you for using 📜LootsheetNPC5e! 🤗</h2>
     <p>The module was was installed or updated.</p>
     <div class="hideinfo">

--- a/src/templates/partials/welcomeScreen/patchnotes.hbs
+++ b/src/templates/partials/welcomeScreen/patchnotes.hbs
@@ -4,8 +4,15 @@
     </header>
     <h2>3.5.8</h2>
     <ul style="list-style: none;">
-        <li>Fixes for currency generation</li>
-        <li>Fixes handling for rolltlables in rolltables</li>
+        <li>Currency
+            <ul style="list-style: none;">
+                <li>Fixed: items with a low gold price like 0.01 are no longer traded for free.</li>
+                <li>Fixed: A string like <pre>1d20[gp],3d4[sp]</pre> will now propperly generate currency.</li>
+                <li>Fixed: prices in the inventory will no longer cut small numbers.</li>
+            </ul>
+        </li>
+        <li>Handling for player actors with old currency</li>
+        <li>Fixes handling for rolltables in rolltables</li>
         <li>Reduced the number of updates to the actors inventory when adding multiple quantities of an item.</li>
         <li>change the token HUD interface button to make lootable and not only observable</li>
         <li>replaced depreceated `ENTITY_PERMISSIONS` references</li>

--- a/src/templates/partials/welcomeScreen/patchnotes.hbs
+++ b/src/templates/partials/welcomeScreen/patchnotes.hbs
@@ -2,6 +2,17 @@
     <header>
         <h1>Patchnotes</h1>
     </header>
+    <h2>3.5.8</h2>
+    <ul style="list-style: none;">
+        <li>Fixes for currency generation</li>
+        <li>Fixes handling for rolltlables in rolltables</li>
+        <li>Reduced the number of updates to the actors inventory when adding multiple quantities of an item.</li>
+        <li>change the token HUD interface button to make lootable and not only observable</li>
+        <li>replaced depreceated `ENTITY_PERMISSIONS` references</li>
+        <li>Fixed a check that previously caused errors for players</li>
+        <li>Optimized vertical sizing for trade/loot tab inventories.</li>
+        <li>Fixed webfont paths</li>
+    </ul>
     <h2 id="v3.4.5">v3.4.10</h2>
     <ul style="list-style: none;">
         <li>


### PR DESCRIPTION
Change the button in the token hud to make token(s) lootable and not only observable.

Replaced some old references to FoundryVTT permission levels with up to date reference.