### PR TITLE
fix(issue: #353): update catche when try to get random spell an set s…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "fvtt-loot-sheet-npc-5e",
-  "version": "3.5.11",
+  "version": "3.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "fvtt-loot-sheet-npc-5e",
-      "version": "3.5.11",
+      "version": "3.6.0",
       "bundleDependencies": [
         "tippy.js"
       ],

--- a/src/modules/helper/ItemHelper.js
+++ b/src/modules/helper/ItemHelper.js
@@ -1,3 +1,4 @@
+import Item5e from "/systems/dnd5e/module/item/entity.js";
 import { MODULE } from '../data/moduleConstants.js';
 
 class ItemHelper {


### PR DESCRIPTION
## Summary
![spell](https://img.shields.io/github/labels/jopeek/fvtt-loot-sheet-npc-5e/spell) and spell level on create scroll

## Details
Call the method `updateSpellCache` when try to get a ~randomSpell, additionaly when call the method createScrollFromSpell define the type as spell and pass the level of 

## Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
> 'closes #353 ' 

### Fixes
 > * fixes #353 
 
### Closes
* closes #353 
* closes #355


## Checklist:
- [x] I have performed a self-review of my code

## By
@rastered26