### PR TITLE
Changed entity.js import to use a relative path.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,10 @@ const staticFiles = ["templates", "libs", "fonts", "styles", "icons", "lang", "p
  */
 const config = {
     input: "src/lootsheetnpc5e.js",
-    external: ["../../../../../systems/dnd5e/module/actor/sheets/npc.js"],
+    external: [
+        "../../../../../systems/dnd5e/module/actor/sheets/npc.js",
+        "../../../../systems/dnd5e/module/item/entity.js",
+    ],
     output: {
         dir: "dist/",
         format: "es",

--- a/src/modules/helper/ItemHelper.js
+++ b/src/modules/helper/ItemHelper.js
@@ -1,4 +1,4 @@
-import Item5e from "/systems/dnd5e/module/item/entity.js";
+import Item5e from "../../../../systems/dnd5e/module/item/entity.js";
 import { MODULE } from '../data/moduleConstants.js';
 
 class ItemHelper {


### PR DESCRIPTION
## Summary
Changes an entity.js import to use a relative path, and declares the import as external for rollup.

## Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
 closes #368 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings