### PR TITLE
Use TABS static variable

### DIFF
--- a/lootsheet-simple.js
+++ b/lootsheet-simple.js
@@ -75,6 +75,12 @@ class QuantityDialog extends Dialog {
 class LootSheet5eNPC extends dnd5e.applications.actor.ActorSheet5eNPC2 {
   static SOCKET = 'module.lootsheet-simple'
 
+  /** @override */
+  static TABS = [
+    { tab: "features", label: "DND5E.Inventory", svg: "backpack" },
+    { tab: "biography", label: "DND5E.Biography", icon: "fas fa-feather" },
+  ];
+
   get template() {
     // adding the #equals and #unequals handlebars helper
     Handlebars.registerHelper('equals', function (arg1, arg2, options) {
@@ -312,35 +318,6 @@ class LootSheet5eNPC extends dnd5e.applications.actor.ActorSheet5eNPC2 {
 
     // Sheet Type
     html.find('.sheet-type').change((ev) => this._changeSheetType(ev, html))
-
-    // Select the <nav> element and find all <a> elements inside it
-    const nav = $('.loot-sheet-npc nav.tabs')
-    const links = nav.find('a.item.control')
-
-    // Check if the first tab's data-tab attribute is not "features"
-    if (links.first().attr('data-tooltip') !== 'DND5E.Inventory') {
-      // Move the second <a> to the first position
-      if (links.eq(1).length) {
-        links.eq(1).insertBefore(links.eq(0)) // Move the second <a> before the first <a>
-      }
-
-      // Move the fifth <a> to the second position
-      if (links.eq(4).length) {
-        links.eq(4).insertAfter(nav.find('a.item.control').first()) // Move the fifth <a> to after the new first <a>
-      }
-
-      // Remove the remaining <a> elements (original first, third, and fourth)
-      nav.find('a.item.control').slice(2).remove() // Remove from the third onward
-
-      // Set the data-tab attribute to features
-      nav.find('a.item.control').first().attr('data-tab', 'features')
-
-      // Check if no <li> elements have the 'active' class
-      if (!nav.find('a.active').length) {
-        // Add the "active" class to the new first <a> element if no other <li> is active
-        nav.find('a.item.control').first().addClass('active')
-      }
-    }
 
     // Roll Table
     //html.find('.sheet-type').change(ev => this._changeSheetType(ev, html));


### PR DESCRIPTION
Simplify module to override the default TABS static variable rather than adjusting html directly in `activateListeners` method.